### PR TITLE
Class for intermediate folders

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -92,7 +92,7 @@ export default class FolderHighlighter extends Plugin {
                 }
             }
         }
-		const intermediateFolders = this.getAllFoldersInPath(activeFile.path);
+		const intermediateFolders = this.getIntermediateFoldersInPath(activeFile.path);
 		for (let intermediateFolder of intermediateFolders) {
 			if (intermediateFolder) {
 				intermediateFolder.classList.add("highlighted-intermediate-folder");

--- a/main.ts
+++ b/main.ts
@@ -76,7 +76,7 @@ export default class FolderHighlighter extends Plugin {
         // Remove all previous highlights
         const allFolders = document.querySelectorAll(".nav-folder");
         allFolders.forEach((folder) => {
-            folder.classList.remove("highlighted-folder", "highlighted-parent-folder");
+            folder.classList.remove("highlighted-folder", "highlighted-parent-folder", "highlighted-intermediate-folder");
         });
 
         // Highlight the folder containing the active note
@@ -92,6 +92,12 @@ export default class FolderHighlighter extends Plugin {
                 }
             }
         }
+		const intermediateFolders = this.getAllFoldersInPath(activeFile.path);
+		for (let intermediateFolder of intermediateFolders) {
+			if (intermediateFolder) {
+				intermediateFolder.classList.add("highlighted-intermediate-folder");
+			}
+		}
     }
 
     getParentFolderElement(filePath: string): Element | null {
@@ -123,6 +129,23 @@ export default class FolderHighlighter extends Plugin {
 
         return null;
     }
+	
+	getIntermediateFoldersInPath(filePath) {
+	    let intermediateFolders = [];
+	    const folderPaths = filePath.split("/");
+	    folderPaths.pop();
+		
+	    while (folderPaths.length > 1) {
+			const folderName = folderPaths.join("/");
+			const folderElement = document.querySelector(`[data-path="${folderName}"]`);
+			if (folderElement) {
+				intermediateFolders.push(folderElement.closest(".nav-folder"));
+			}
+			folderPaths.pop();
+	    }
+		
+	    return intermediateFolders;
+	}
 
     updateStyles() {
         if (!this.styleEl) {


### PR DESCRIPTION
Hi!

I allowed myself to fork your repo and add an iterative step to tag intermediate folders with the class "highlighted-intermediate-folder". This way, it gives the CSS control to highlight individual folders even when the deepest one is folded.

![image](https://github.com/user-attachments/assets/9245afe0-022f-45b6-86ea-b414794e462d)

![image](https://github.com/user-attachments/assets/a4a1b4c2-848a-42ad-9d49-fdf13332de16)

It should not change anything in your own styling as I just added an inexisting class so far.
Class is not added on the root, neither on the direct folder of the active note. Just the in between.

Cheers!