### PR TITLE
Clears the folder highlight when there is no active file

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -140,7 +140,10 @@ export default class FolderHighlighter extends Plugin {
 
 	highlightFolders() {
 		const activeFile = this.app.workspace.getActiveFile();
-		if (!activeFile) return;
+		if (!activeFile) {
+			this.clearHighlight();	
+			return;
+		}
 
 		// Remove all previous highlights
 		const allFolders = document.querySelectorAll(".nav-folder");
@@ -176,6 +179,13 @@ export default class FolderHighlighter extends Plugin {
 			}
 		}
 	}
+
+	clearHighlight() {
+		document.querySelectorAll(".highlighted-folder").forEach((el) => {
+		  el.classList.remove("highlighted-folder");
+		  el.classList.remove("highlighted-parent-folder");
+		});
+	  }
 
 	getParentFolderElement(filePath: string): Element | null {
 		const folderPaths = filePath.split("/");


### PR DESCRIPTION
### Problem
If I have a file open in Obsidian, the respective folder gets highlighted and it works fine. Once I close the file, and there are no more files open, it does not remove the highlight from the folder from which the file was open.

### Solution
I added a `clearHighlight` function, which on `active-leaf-change` will check if there is no current active file, then it will call clear the highlight.

